### PR TITLE
Bump epic and ip6

### DIFF
--- a/pkgs/epic/default.nix
+++ b/pkgs/epic/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "epic";
-  version = "unstable-2022-08-06";
+  version = "unstable-2022-09-03";
 
   src = fetchFromGitHub {
     owner = "eic";
     repo = pname;
-    rev = "d1336e5ff1b1f7adfe3defbd03fe7ac0cc1f1035";
-    hash = "sha256-kkLZZF07lon/opAmUzgvhdYKe/L8BByNGBZNsVn9Wxc=";
+    rev = "3651c6dc504bb03798c424cd4e064599d421e5ae";
+    hash = "sha256-vtM427u9kBRrsjcNn7aU8uVAKXDZpg+mypjN0MWtCdc=";
   };
 
   postPatch = ''
@@ -24,9 +24,6 @@ stdenv.mkDerivation rec {
 
     substituteInPlace templates/epic.xml.jinja2 \
       --replace '"ip6/' '"''${BEAMLINE_PATH}/ip6/'
-  '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace templates/setup.sh.in \
-      --replace LD_LIBRARY_PATH DYLD_LIBRARY_PATH
   '';
 
   nativeBuildInputs = [

--- a/pkgs/ip6/default.nix
+++ b/pkgs/ip6/default.nix
@@ -9,19 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ip6";
-  version = "unstable-2022-08-24";
+  version = "unstable-2022-09-03";
 
   src = fetchFromGitHub {
     owner = "eic";
     repo = pname;
-    rev = "7d8d142cd701f6fc88f62b92fb9684c8b999ef5a";
-    hash = "sha256-xfB/MKntQXoDWXi9NkqQ7GTrU42AY98vQHLcu6fo/Lc=";
+    rev = "533d83a4e7c993b9a3b729ba20c89a7b01c41e27";
+    hash = "sha256-w8c/3HNFj+8mIlPDsK3Q5A/hJoMtzqwzpBJsa7JgwJc=";
   };
-
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace templates/setup.sh.in \
-      --replace LD_LIBRARY_PATH DYLD_LIBRARY_PATH
-  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Includes a fix for epic needed for the newest version of DD4hep