### PR TITLE
root: disable rpath

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -60,7 +60,7 @@ final: prev: with final; {
   npsim = callPackage pkgs/npsim {};
 
   root = prev.root.overrideAttrs (prev: {
-    cmakeFlags = prev.cmakeFlags ++ [
+    cmakeFlags = (builtins.filter (flag: flag != "-Drpath=OFF") prev.cmakeFlags) ++ [
       "-DCMAKE_CXX_STANDARD=17"
       "-Dssl=ON" # for Gaudi
       "-Dbuiltin_unuran=ON"


### PR DESCRIPTION
This fixes errors like

    ERROR: failed to load libathena.dylib: dlopen(libathena.dylib, 0x0005): Library not loaded: '@rpath/libRint.so'

that started popping up on (recent?) macOS builds.