### PR TITLE
juggler: fix builds for SIP, provide library paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         name: epic-eic
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix flake check --keep-going --print-build-logs --no-write-lock-file
+    - run: nix flake check --keep-going --print-build-logs --no-write-lock-file --cores `nproc || getconf _NPROCESSORS_ONLN`

--- a/pkgs/gaudi/default.nix
+++ b/pkgs/gaudi/default.nix
@@ -116,6 +116,8 @@ stdenv.mkDerivation rec {
       --prefix PYTHONPATH : "$PYTHONPATH:$out/${python3.sitePackages}"
   '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     description = "A reconstruction framework";
     longDescription = ''

--- a/pkgs/gaudi/default.nix
+++ b/pkgs/gaudi/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , fetchpatch
 , aida
+, bash
 , boost
 , cmake
 , clhep
@@ -83,6 +84,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs --build GaudiKernel/scripts/
+    substituteInPlace cmake/GaudiToolbox.cmake \
+      --replace '/bin/sh' '${bash}/bin/sh'
 
     sed -i GaudiHive/src/PRGraph/PrecedenceRulesGraph.cpp \
       -e '1i#include <boost/filesystem/fstream.hpp>'

--- a/pkgs/gaudi/setup-hook.sh
+++ b/pkgs/gaudi/setup-hook.sh
@@ -1,0 +1,5 @@
+if [[ "$(uname -s)" = "Darwin" ]] || [[ "$OSTYPE" == "darwin"* ]]; then
+	export DYLD_LIBRARY_PATH="@out@/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+else
+	export LD_LIBRARY_PATH="@out@/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi

--- a/pkgs/juggler/default.nix
+++ b/pkgs/juggler/default.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-narrowing";
 
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     description = "Concurrent Event Processor for EIC Experiments Based on the Gaudi Framework";
     license = licenses.lgpl3Only;

--- a/pkgs/juggler/default.nix
+++ b/pkgs/juggler/default.nix
@@ -37,12 +37,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
   ];
+  propagatedBuildInputs = [
+    gaudi
+  ];
   buildInputs = [
     acts
     edm4eic
     edm4hep
     dd4hep
-    gaudi
     genfit
     podio
     root

--- a/pkgs/juggler/setup-hook.sh
+++ b/pkgs/juggler/setup-hook.sh
@@ -1,0 +1,5 @@
+if [[ "$(uname -s)" = "Darwin" ]] || [[ "$OSTYPE" == "darwin"* ]]; then
+	export DYLD_LIBRARY_PATH="@out@/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+else
+	export LD_LIBRARY_PATH="@out@/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi


### PR DESCRIPTION
This fixes errors like

    ERROR: failed to load libathena.dylib: dlopen(libathena.dylib, 0x0005): Library not loaded: '@rpath/libRint.so'

that started popping up on (recent?) macOS builds.