### PR TITLE
eicrecon,npdet,npsim: drop explicit dependency on fmt

### DIFF
--- a/pkgs/eicrecon/default.nix
+++ b/pkgs/eicrecon/default.nix
@@ -11,7 +11,6 @@
 , eigen
 , fastjet
 , irt
-, fmt_8
 , jana2
 , nlohmann_json
 , podio
@@ -60,7 +59,6 @@ stdenv.mkDerivation rec {
     edm4hep
     _fastjet
     eigen
-    fmt_8
     irt
     jana2
     nlohmann_json

--- a/pkgs/npdet/default.nix
+++ b/pkgs/npdet/default.nix
@@ -4,7 +4,6 @@
 , fetchFromGitLab
 , cmake
 , dd4hep
-, fmt_8
 , opencascade-occt
 , podio
 , python3
@@ -53,7 +52,6 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     dd4hep
-    fmt_8
     opencascade-occt
     podio
     python3

--- a/pkgs/npsim/default.nix
+++ b/pkgs/npsim/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , cmake
 , dd4hep
-, fmt_8
 , opencascade-occt
 , spdlog
 , fontconfig
@@ -37,7 +36,6 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     dd4hep
-    fmt_8
     opencascade-occt
     spdlog
   ] ++ lib.optional stdenv.isLinux [


### PR DESCRIPTION
Instead let spdlog.propagatedBuildInputs provide it.