### PR TITLE
epic: update 26.04.1 -> 26.05.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,16 +101,16 @@
     "epic-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1775489462,
-        "narHash": "sha256-F0qffgDYiYe0CCcsnF8aCOv1gNxvFNz82GadTq9bR/w=",
+        "lastModified": 1778197960,
+        "narHash": "sha256-6ZK3zZ/wu9nDrv5iehgvyJ7vrBtcYR1CFXfaL3zbnPY=",
         "owner": "eic",
         "repo": "epic",
-        "rev": "a3ea8461206b892453ecee7c69ed37ad8b49147b",
+        "rev": "781f99c81783f3836045fdacfed0950d086983f0",
         "type": "github"
       },
       "original": {
         "owner": "eic",
-        "ref": "26.04.1",
+        "ref": "26.05.0",
         "repo": "epic",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
     flake = false;
   };
   inputs.epic-src = {
-    url = "github:eic/epic/26.04.1";
+    url = "github:eic/epic/26.05.0";
     flake = false;
   };
   inputs.eicrecon-src = {

--- a/pkgs/epic/default.nix
+++ b/pkgs/epic/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "epic";
-  version = "26.04.1.${epic-src.shortRev or "dirty"}";
+  version = "26.05.0.${epic-src.shortRev or "dirty"}";
 
   src = epic-src;
 


### PR DESCRIPTION
Automated update of **eic/epic** from 26.04.1 to 26.05.0.

This PR was created automatically by the check-updates workflow.

Release: https://github.com/eic/epic/releases/tag/26.05.0