### PR TITLE
eicrecon: update 1.36.1 -> 1.37.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,16 +84,16 @@
     "eicrecon-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1775673232,
-        "narHash": "sha256-d0S4v0pNXi0yPY8XfxKEgZZGMLcnaAd6gNdtUA164V4=",
+        "lastModified": 1778201960,
+        "narHash": "sha256-O8qi9PRtlNFKhNLnmQtghtzsZ+wnI6SFJg0XyL4mpL0=",
         "owner": "eic",
         "repo": "EICrecon",
-        "rev": "c43a642abdfea7fd84ea2c4ad92f93ce8f989e79",
+        "rev": "2f8de6248c05420f8be18b37c5f460b6e6ce3d64",
         "type": "github"
       },
       "original": {
         "owner": "eic",
-        "ref": "v1.36.1",
+        "ref": "v1.37.1",
         "repo": "EICrecon",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
     flake = false;
   };
   inputs.eicrecon-src = {
-    url = "github:eic/EICrecon/v1.36.1";
+    url = "github:eic/EICrecon/v1.37.1";
     flake = false;
   };
   inputs.geant4-src = {

--- a/pkgs/eicrecon/default.nix
+++ b/pkgs/eicrecon/default.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "EICrecon";
-  version = "1.36.1-${eicrecon-src.shortRev or "dirty"}";
+  version = "1.37.1-${eicrecon-src.shortRev or "dirty"}";
 
   src = eicrecon-src;
 


### PR DESCRIPTION
Automated update of **eic/EICrecon** from v1.36.1 to v1.37.1.

This PR was created automatically by the check-updates workflow.

Release: https://github.com/eic/EICrecon/releases/tag/v1.37.1